### PR TITLE
Apply CSS only to own menu

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -69,11 +69,11 @@
     display: block;
 }
 
-.atto_menuentry {
+.atto_morefontcolors_button .atto_menuentry {
     list-style-type: none;
 }
 
-.atto_menuentry a[role="menuitem"]{
+.atto_morefontcolors_button .atto_menuentry a[role="menuitem"]{
     display: flex;
     display: -webkit-flex;
 }


### PR DESCRIPTION
It is important to focus all CSS on the plugin itself, otherwise it can inadvertently cause problems with other plugins or Moodle itself.

Cheers!