### PR TITLE
Behat test failing - Multiple empty lines not allowed. 

### DIFF
--- a/tests/behat/morefontcolors.feature
+++ b/tests/behat/morefontcolors.feature
@@ -29,4 +29,3 @@ Feature: Atto more font colours button
     When I click on "//div[@data-color='#123456']" "xpath_element"
     And I press "Update profile"
     Then "//span[normalize-space(.)='Water lillies' and contains(@style, '18,52,86')]" "xpath_element" should exist
-


### PR DESCRIPTION
Behat test was failing with the following message:

lib/editor/atto/plugins/morefontcolors/tests/behat/morefontcolors.feature
  33    Multiple empty lines are not allowed   no-multiple-empty-lines

Solution: Just deleted one of the empty line at the end of the file.

Let me know if you have any questions or concerns.